### PR TITLE
update shebang lines of cli2 to python3

### DIFF
--- a/cli/categories.py
+++ b/cli/categories.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # IBM_PROLOG_BEGIN_TAG
 #
 # Copyright 2019,2020 IBM International Business Machines Corp.

--- a/cli/datasets.py
+++ b/cli/datasets.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # IBM_PROLOG_BEGIN_TAG
 #
 # Copyright 2019,2020 IBM International Business Machines Corp.

--- a/cli/deployed-models.py
+++ b/cli/deployed-models.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # IBM_PROLOG_BEGIN_TAG
 #
 # Copyright 2019,2020 IBM International Business Machines Corp.

--- a/cli/dltasks.py
+++ b/cli/dltasks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # IBM_PROLOG_BEGIN_TAG
 #
 # Copyright 2019,2020 IBM International Business Machines Corp.

--- a/cli/files.py
+++ b/cli/files.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # IBM_PROLOG_BEGIN_TAG
 #
 # Copyright 2019,2020 IBM International Business Machines Corp.

--- a/cli/object-labels.py
+++ b/cli/object-labels.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # IBM_PROLOG_BEGIN_TAG
 #
 # Copyright 2019,2020 IBM International Business Machines Corp.

--- a/cli/object-tags.py
+++ b/cli/object-tags.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # IBM_PROLOG_BEGIN_TAG
 #
 # Copyright 2019,2020 IBM International Business Machines Corp.

--- a/cli/pgmodels
+++ b/cli/pgmodels
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 
 if sys.hexversion < 0x02060000:

--- a/cli/projects.py
+++ b/cli/projects.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # IBM_PROLOG_BEGIN_TAG
 #
 # Copyright 2019,2020 IBM International Business Machines Corp.

--- a/cli/trained-models.py
+++ b/cli/trained-models.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # IBM_PROLOG_BEGIN_TAG
 #
 # Copyright 2019,2020 IBM International Business Machines Corp.

--- a/cli/users.py
+++ b/cli/users.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # IBM_PROLOG_BEGIN_TAG
 #
 # Copyright 2019,2020 IBM International Business Machines Corp.

--- a/cli/vision
+++ b/cli/vision
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # IBM_PROLOG_BEGIN_TAG
 #
 # Copyright 2019,2020 IBM International Business Machines Corp.


### PR DESCRIPTION
Hey Carl,

As we discussed I ran into issues with needing to update the shebang line from /usr/bin/env/python to /usr/bin/env/python3 so that it would use python3 to run the code. I tried creating symlinks for python -> python3, but still ran into issues with it.

As python2 is EOL, maybe we could consider updating these lines to python3 in order to specify it as python3 usage.