### PR TITLE
visual_inspector_dump.py update to check for false negative

### DIFF
--- a/misc/visual_inspector_dump.py
+++ b/misc/visual_inspector_dump.py
@@ -108,6 +108,10 @@ def getInputs():
   parser = argparse.ArgumentParser(description="Tool to classify all images in a directory")
   parser.add_argument('--dsid', action="store", dest="dsid", required=False,
                       help="(Optional) UUID of a target dataset")
+  parser.add_argument('--category', action="store", dest="categoryname", required=False,
+                      help="(Optional) Name of the category")
+  parser.add_argument('--objlabel', action="store", dest="objlabel", required=False,
+                      help="(Optional) Name of the object label")
   parser.add_argument('--url', action="store", dest="url", required=True,
                       help="Vision URL eg https://ip/powerai-vision WITHOUT trailing slash or /api")
   parser.add_argument('--user', action="store", dest="user", required=True,
@@ -289,7 +293,7 @@ def getUserMetadata(dsId):
 
 
 # return an array of files with extra data attached like the datasetid, URL, and owner that are not available via the API response directly
-def fetchCSV(dsid=None, url="http://ip/instance-name"):
+def fetchCSV(dsid=None, categoryname=None, objlabel=None, url="http://ip/instance-name"):
   # get list of all datasets
   logging.info("Retrieving global dataset list...")
   datasets = getDatasets()
@@ -304,6 +308,7 @@ def fetchCSV(dsid=None, url="http://ip/instance-name"):
   for dataset in datasets:
     #get files for this specific dataset
     dscsvdata = getUserMetadata(dataset['_id'])
+    dsfiles = getFileList(dataset['_id'])
     logging.info("Fetched %7d items in Dataset %s = %s" % (len(dscsvdata), dataset['_id'], dataset['name']))
     # create a unique URL and some other book keeping items for this file
     for file in dscsvdata:
@@ -312,6 +317,16 @@ def fetchCSV(dsid=None, url="http://ip/instance-name"):
       file['DataSetName'] = dataset['name']
       file['Owner'] = dataset['owner']
       file['URL'] = url + "/" + "#/datasets/" + dataset['_id'] + "/label?imageId=" + file['#file_id']
+      # The 'FalseNegative' field is used to denote if a image has been 'tagged' that the
+      # InspectionPassed is not correct after manual visual inspection has been done.
+      # By default we set the value to 'False'  and only if either the image has the
+      # 'category_name' or an object label of objlabel, set it to 'True'
+      file['FalseNegative'] = 'False'
+      dsfile = [dsfile for dsfile in dsfiles if dsfile['_id'] == file['#file_id']]
+      if 'tag_list' in dsfile[0].keys():
+        tagobject = [tagobject for tagobject in dsfile[0]['tag_list'] if tagobject['tag_name'] == objlabel]
+      if dsfile[0].get('category_name', "") == categoryname or tagobject:
+        file['FalseNegative'] = 'True'
     # append this into the master list for csv processing...
     rows.extend(dscsvdata)
   
@@ -321,17 +336,18 @@ def fetchCSV(dsid=None, url="http://ip/instance-name"):
 # -------------------------------------
 # Generate CSV from dictionary
 #
-def generateCSV(dsid=None, url="http://ip/instance-name", filename="output.csv", showall=False, newerthan=0):
+def generateCSV(dsid=None, categoryname=None, objlabel=None, url="http://ip/instance-name", filename="output.csv", showall=False, newerthan=0):
   numrows = 0
 
-  rows = fetchCSV(dsid=dsid, url=url)
+  rows = fetchCSV(dsid=dsid, categoryname=categoryname, objlabel=objlabel, url=url)
   
   # Generate minimal info CSV
   with open(filename, 'w', newline='') as csvfile:
     writer = csv.writer(csvfile)
     headers = ['DataSetID', 'DataSetName', 'Owner', 'URL', 'InspectionType', 'FormattedDate', 'Timestamp', 'Reference',
                'TriggerString', 'InspectionName', 'InspectionPassed',
-               'InspectionLocation', 'InspectionDevice', 'InspectionModelType', 'InspectionLabels', 'FailedLabels']
+               'InspectionLocation', 'InspectionDevice', 'InspectionModelType', 'InspectionLabels', 'FailedLabels',
+               'FalseNegative']
     # headers.extend(['Metadata%d' % i for i in range(25)])
     writer.writerow(headers)
     # writer.writeheader()
@@ -352,8 +368,16 @@ def generateCSV(dsid=None, url="http://ip/instance-name", filename="output.csv",
         if (not showall) and (row['InspectionType'] == "Collected"):
           # NOTE Special behavior here. We skip this row since we're filtering out training data
           continue
-        if int(row['Timestamp']) < newerthan:
+        if (row['Timestamp'] is None):
+          logging.debug("WARN: No timestamp for %s" % rows[0]['URL'])
+          continue
+        if (row['Timestamp'].strip() == ""):
+          logging.debug("WARN: No timestamp for %s" % rows[0]['URL'])
+          continue
+        if int(row['Timestamp']) < newerthan and row['FalseNegative'] == 'False':
           # NOTE Special behavior here. We skip this row since we're filtering out all records older than the "newerthan" arg.
+          # However, if the 'FalseNegative' field is set to 'True' we want to include the item irregardless of
+          # the Timestamp filter
           # If the user didn't specify newerthan, then we default to 0, which will return -all- timestamps.
           continue
       elif showall:
@@ -395,12 +419,12 @@ if __name__ == '__main__':
 
     if args.migrate:
       logging.debug("Starting migration of down-level inspector data to metadata APIs...")
-      numfilesmigrated = saveMetadata(dsid=args.dsid, url=args.url)
+      numfilesmigrated = saveMetadata(dsid=args.dsid, categoryname=args.categoryname, url=args.url)
       logging.info("Finished migrating data for %d files." % (numfilesmigrated))
 
     elif args.output:
       logging.debug("Saving CSV metadata to %s" % (args.output))
-      rowswritten = generateCSV(dsid=args.dsid, url=args.url, filename=args.output, showall=args.showall, newerthan=int(args.newerthan))
+      rowswritten = generateCSV(dsid=args.dsid, categoryname=args.categoryname, objlabel=args.objlabel, url=args.url, filename=args.output, showall=args.showall, newerthan=int(args.newerthan))
       logging.info("Wrote   %7d rows to %s." % (rowswritten, args.output))
     else:
       logging.error("Did not find a valid command or argument to parse.")


### PR DESCRIPTION
flags.

Add support for new --category and --objlabel command line
parameters that take a category and object label name as
indicators of an inspection being a FALSE_NEGATIVE. If either
is present, set the FALSE_NEGATIVE field to 'True'.

Additionally, if the FALSE_NEGATIVE field is 'True', ignore
the --newerthan filter and include the inspection in the list
of inspections to be dumped.