### PR TITLE
Exclude any data set earmarked as "test" data from data dumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ bats/
 *.egg-info/
 build/
 dist/
+.idea


### PR DESCRIPTION
When working with a particular workflow, clients might need to
curate and manage whether particular inference results are visible
for anaylsis in external programs. This change adds a behavior to
"--showall" and the default export function of the script to omit
any data set that is marked with a particular naming scheme that
ends in "_test" (case insensitive). If the user wants to include
these data sets, they should pass --showall to include them.