### PR TITLE
Fix bad model thumbnail path and setup to pull from docker hub

### DIFF
--- a/misc/migrationAides/build_image.sh
+++ b/misc/migrationAides/build_image.sh
@@ -58,7 +58,8 @@ then
 fi
 
 ARCH=$(uname -m)
-IMAGE_NAME="mvi-migration-tool_${ARCH}"
+TAG="${TAG}_${ARCH}"
+IMAGE_NAME="bcarl/mvi-migration"
 
 mkdir -p "${WORK_DIR}"
 cd "${WORK_DIR}"
@@ -74,5 +75,5 @@ cp -p "${ROOT_DIR}/Dockerfile" .
 # Build release package image
 docker build -t ${IMAGE_NAME}:${TAG} -f Dockerfile .
 
-docker save ${IMAGE_NAME}:${TAG} > "${IMAGE_NAME}:${TAG}"
+docker save ${IMAGE_NAME}:${TAG} > "mvi-migration:${TAG}"
 cd "${ROOT_DIR}"

--- a/misc/migrationAides/cmds/migrateMvi.py
+++ b/misc/migrationAides/cmds/migrateMvi.py
@@ -293,7 +293,7 @@ class SourceAccess:
         self.ocCmd = "oc"
         self.ocFlags = ""
         self.deployment = {}
-        self.imageName = "mvi-migration-tool"
+        self.imageName = "bcarl/mvi-migration"
         self.deploymentName = deploymentName
         self.info = srcInfo
 
@@ -415,7 +415,7 @@ class StandaloneSource(SourceAccess):
         super().__init__(deploymentName, srcInfo)
         self.helmCmd = "/opt/ibm/vision/bin/helm.sh"
         self.ocCmd = "/opt/ibm/vision/bin/kubectl.sh"
-        self.imageName = "mvi-migration-tool_ppc64le:1.0.0"
+        self.imageName = "docker.io/bcarl/mvi-migration:1.0.0_ppc64le"
         logger.debug(f"StandaloneSource: {str(self.__dict__)}")
 
     def _collectHelmInfo(self):


### PR DESCRIPTION
This PR fixes a problem found at a customer site where the trained-model thumbnails were not being seen in the UI.
It also takes the first steps to pulling the migration container from docker hub.