### PR TITLE
Add 'system' resource to get information about the server.

### DIFF
--- a/cli/vision
+++ b/cli/vision
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # IBM_PROLOG_BEGIN_TAG
 #
-# Copyright 2019,2020 IBM International Business Machines Corp.
+# Copyright 2019,2022 IBM International Business Machines Corp.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/cli/vision
+++ b/cli/vision
@@ -42,6 +42,7 @@ Where:
       deployed-models -- work with deployed models
       projects       -- work with projects
       users          -- work with users
+      system         -- server system information
 
 'vision' provides access to Maximo Visual Inspection resources via the ReST API.
 Use 'vision <resource> --help' for more information about operating on a given resource"""
@@ -59,6 +60,7 @@ resource_map = {
     "obj-tags": "object-tags",
     "object-labels": "object-labels",
     "object-tags": "object-tags",
+    "system": "system",
     "trained-models": "trained-models",
     "projects": "projects",
     "users": "users"

--- a/lib/vapi/System.py
+++ b/lib/vapi/System.py
@@ -1,6 +1,6 @@
 # IBM_PROLOG_BEGIN_TAG
 #
-# Copyright 2021 IBM International Business Machines Corp.
+# Copyright 2022 IBM International Business Machines Corp.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/lib/vapi/System.py
+++ b/lib/vapi/System.py
@@ -1,0 +1,37 @@
+# IBM_PROLOG_BEGIN_TAG
+#
+# Copyright 2021 IBM International Business Machines Corp.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#           http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#  IBM_PROLOG_END_TAG
+
+
+class System:
+
+    def __init__(self, server):
+        self.server = server
+
+    def info(self):
+        """ Get MVI system info"""
+
+        uri = f"/system"
+        return self.server.get(uri)
+
+    def version(self):
+        """ Get MVI version info"""
+
+        uri = f"/version-info"
+        return self.server.get(uri)
+

--- a/lib/vapi/base.py
+++ b/lib/vapi/base.py
@@ -1,6 +1,6 @@
 # IBM_PROLOG_BEGIN_TAG
 #
-# Copyright 2019,2020 IBM International Business Machines Corp.
+# Copyright 2019,2022 IBM International Business Machines Corp.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/lib/vapi/base.py
+++ b/lib/vapi/base.py
@@ -39,6 +39,7 @@ from vapi.TrainedModels import TrainedModels
 from vapi.DeployedModels import DeployedModels
 from vapi.InferenceResults import InferenceResults
 from vapi.Users import Users
+from vapi.System import System
 
 
 class Base:
@@ -56,10 +57,6 @@ class Base:
 
         if token is None:
             token = os.getenv("VAPI_TOKEN")
-            if token is None:
-                msg = F"Could not find 'VAPI_TOKEN' information in environment or input parameters"
-                logger.error(" MVI:" + msg)
-                raise Exception(msg)
 
         if base_uri is None:
             # Try to construct the base_uri from VAPI_HOST and VAPI_INSTANCE
@@ -98,6 +95,7 @@ class Base:
             self.deployed_models = DeployedModels(self.server)
             self.dnnscripts = DnnScripts(self.server)
             self.users = Users(self.server)
+            self.system = System(self.server)
 
     def raw_http_request(self):
         """ Gets the raw HTTP request for the last request that was sent"""

--- a/lib/vapi_cli/cli_utils.py
+++ b/lib/vapi_cli/cli_utils.py
@@ -1,6 +1,6 @@
 # IBM_PROLOG_BEGIN_TAG
 #
-# Copyright 2019,2020 IBM International Business Machines Corp.
+# Copyright 2019,2022 IBM International Business Machines Corp.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/lib/vapi_cli/cli_utils.py
+++ b/lib/vapi_cli/cli_utils.py
@@ -61,6 +61,7 @@ limit_skip_flag_descriptions = """   --limit        Optional parameter to limit 
                   returning results. Limit and Skip can be used to page
                   through results"""
 
+show_status_code = False
 show_httpdetail = False
 json_only = False
 host_name = None
@@ -172,6 +173,9 @@ def reportApiError(server, msg=None):
     This method also uses global variables 'scripting' and 'show_httpdetail' to control what output
     is generated."""
 
+    if show_status_code:
+        print(f'{{"status_code": {server.status_code()}}}', file=sys.stderr)
+
     try:
         #jsondata = textwrap.indent(json.dumps(server.json(), indent=2), " " * 8)
         jsondata = server.json()
@@ -209,6 +213,9 @@ def reportSuccess(server, msg=None, summaryFields=None):
     :param summaryFields -- list of fields to pull from json objects. If present, JSON will not be shown.
     """
     try:
+        if show_status_code:
+            print(f'{{"status_code": {server.status_code()}}}', file=sys.stderr)
+
         if not json_only:
             if summaryFields is not None:
                 cnt = 0
@@ -252,6 +259,7 @@ def set_output_controls(params):
 
     Output controls are set by parameter or by ENV variable."""
 
+    global show_status_code
     global show_httpdetail
     global json_only
 
@@ -279,6 +287,8 @@ def set_output_controls(params):
         show_httpdetail = "VAPI_HTTPDETAIL" in os.environ
     if not json_only:
         json_only = "VAPI_JSONONLY" in os.environ
+
+    show_status_code = "VAPI_SHOW_STATUS_CODE" in os.environ
 
 
 def print_http_detail(server):

--- a/lib/vapi_cli/system.py
+++ b/lib/vapi_cli/system.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # IBM_PROLOG_BEGIN_TAG
 #
-# Copyright 2021 IBM International Business Machines Corp.
+# Copyright 2022 IBM International Business Machines Corp.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/lib/vapi_cli/system.py
+++ b/lib/vapi_cli/system.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# IBM_PROLOG_BEGIN_TAG
+#
+# Copyright 2021 IBM International Business Machines Corp.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#           http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#  IBM_PROLOG_END_TAG
+
+import logging as logger
+import sys
+import vapi
+import vapi_cli.cli_utils as cli_utils
+from vapi_cli.cli_utils import reportSuccess, reportApiError, translate_flags
+
+# All of Vision Tools requires python 3.6 due to format string
+# Make the check in a common location
+if sys.hexversion < 0x03060000:
+    sys.exit("Python 3.6 or newer is required to run this program.")
+
+info_usage = """
+Usage:
+  system info
+
+Gets info about the MVI server."""
+
+server = None
+
+# ---  Info Operation  -----------------------------------------------
+info_usage = f"""
+Usage:  system info
+
+Gets server system information.
+"""
+
+
+def info(params):
+    """ Gets MVI System info"""
+
+    rsp = server.system.info()
+    if rsp is None or rsp.get("result", "success") != "success":
+        reportApiError(server, f"Failed to get system Info.")
+    else:
+        reportSuccess(server)
+
+
+# ---  Version Operation  --------------------------------------------
+version_usage = f"""
+Usage:  system version
+
+Gets server version information. This operation does not require authentication.
+"""
+
+
+def version(params):
+    """ Gets MVI System info"""
+
+    rsp = server.system.version()
+    if rsp is None or rsp.get("result", "success") != "success":
+        reportApiError(server, f"Failed to get system Info.")
+    else:
+        reportSuccess(server)
+
+cmd_usage = f"""
+Usage:  system {cli_utils.common_cmd_flags} <operation> [<args>...]
+
+Where:
+{cli_utils.common_cmd_flag_descriptions}
+
+   <operation> is required and must be one of:
+      info    -- gets system information
+      version -- gets system version information
+
+Use 'system <operation> --help' for more information on a specific command."""
+
+usage_stmt = {
+    "usage": cmd_usage,
+    "info": info_usage,
+    "version": version_usage
+}
+
+operation_map = {
+    "info": info,
+    "version": version
+}
+
+
+def main(params, cmd_flags=None):
+    global server
+
+    args = cli_utils.get_valid_input(usage_stmt, operation_map, argv=params, cmd_flags=cmd_flags)
+    if args is not None:
+        # When requesting a token, we need to ignore any existing token info
+        if args.cmd_params["<operation>"] == "token":
+            cli_utils.token = ""
+        try:
+            server = vapi.connect_to_server(cli_utils.host_name, cli_utils.token)
+        except Exception as e:
+            print("Error: Failed to setup server.", file=sys.stderr)
+            logger.debug(e)
+            return 1
+
+        args.operation(args.op_params)
+
+
+if __name__ == "__main__":
+    main(None)


### PR DESCRIPTION
This PR adds a `system` resource with the following
```
vision system --help
Usage:  system [--httpdetail] [--jsonoutput] [--host=<host> | --uri=<serverUri>] [--token=<token>] [--log=<level>] <operation> [<args>...]

Where:
   --httpdetail   Causes HTTP message details to be printed to STDERR
                  This information can be useful for debugging purposes or
                  to get the syntax for use with CURL.
   --jsonoutput   Intended to ease use by scripts, all output to STDOUT is in
                  JSON format. By default output to STDOUT is more human
                  friendly
   --host         Identifies the targeted MVI server. If not
                  specified here, the VAPI_HOST environment variable is used.
                  This parameter has been deprecated. It is maintained for 
                  backward compatibility, but will be removed in a future 
                  release of the tools. 
   --uri          Identifies the base URI for the MVI server -- including the
                  '/api' "directory". If not specified, VAPI_BASE_URI
                  environment variable will be used.
   --token        The API Key token. If not specified here, the
                  VAPI_TOKEN environment variable is used.
   --log          Requests logging at the indicated level. Supported levels are
                  'error', 'warn', 'info', and 'debug'

   <operation> is required and must be one of:
      info    -- gets system information
      version -- gets system version information
```